### PR TITLE
Taxonomy GI ids and old tax ids should be multiple-value properties

### DIFF
--- a/src/main/java/com/era7/bioinfo/bio4j/titan/programs/InitBio4jTitan.java
+++ b/src/main/java/com/era7/bioinfo/bio4j/titan/programs/InitBio4jTitan.java
@@ -290,8 +290,8 @@ public class InitBio4jTitan implements Executable {
         
         
         //---NCBI TAXON---                
-        graph.makeKey(NCBITaxonNode.GI_IDS_PROPERTY).dataType(String.class).unique().indexed(Vertex.class).make();
-        graph.makeKey(NCBITaxonNode.OLD_TAX_IDS_PROPERTY).dataType(String.class).unique().indexed(Vertex.class).make();
+        graph.makeKey(NCBITaxonNode.GI_IDS_PROPERTY).dataType(String.class).list().unique().indexed(Vertex.class).make();
+        graph.makeKey(NCBITaxonNode.OLD_TAX_IDS_PROPERTY).dataType(String.class).list().unique().indexed(Vertex.class).make();
         
     }
 


### PR DESCRIPTION
Here `.list()` thing is important as it's multiple-value property:

``` java
graph.makeKey(NCBITaxonNode.GI_IDS_PROPERTY).dataType(String.class).list().unique().indexed(Vertex.class).make();
graph.makeKey(NCBITaxonNode.OLD_TAX_IDS_PROPERTY).dataType(String.class).list().unique().indexed(Vertex.class).make();
```

[TitanDB manual](https://github.com/thinkaurelius/titan/wiki/Type-Definition-Overview#single-and-multi-value-keys) for reference.

See ohnosequences/bio4j-scala#18
